### PR TITLE
feat: :sparkles: added brief description to frontmatter

### DIFF
--- a/docs/api/mod_loader_config.md
+++ b/docs/api/mod_loader_config.md
@@ -1,3 +1,7 @@
+---
+description: Class for managing per-mod configurations.
+---
+
 # ModLoaderConfig
 **Inherits**: Object
 

--- a/docs/api/mod_loader_deprecated.md
+++ b/docs/api/mod_loader_deprecated.md
@@ -1,3 +1,7 @@
+---
+description: API methods for deprecating funcs. Can be used by mods with public APIs.
+---
+
 # ModLoaderDeprecated
 **Inherits**: Object
 

--- a/docs/api/mod_loader_hook_chain.md
+++ b/docs/api/mod_loader_hook_chain.md
@@ -1,3 +1,7 @@
+---
+description: Small class to keep the state of hook execution chains and move between mod hook calls.
+---
+
 # ModLoaderHookChain
 **Inherits**: RefCounted
 

--- a/docs/api/mod_loader_log.md
+++ b/docs/api/mod_loader_log.md
@@ -1,3 +1,7 @@
+---
+description: This Class provides methods for logging, retrieving logged data, and internal methods for working with log files.
+---
+
 # ModLoaderLog
 **Inherits**: Object
 

--- a/docs/api/mod_loader_log_compare.md
+++ b/docs/api/mod_loader_log_compare.md
@@ -1,0 +1,10 @@
+# ModLoaderLog.ModLoaderLogCompare
+**Inherits**: RefCounted
+
+
+
+<hr style="border-width: thick">
+
+## Method Descriptions
+### • [`#!gd bool`](https://docs.godotengine.org/en/stable/classes/class_bool.html) <code class="highlight">time(a: [ModLoaderLog.ModLoaderLogEntry](mod_loader_log._mod_loader_log_entry.md), b: [ModLoaderLog.ModLoaderLogEntry](mod_loader_log._mod_loader_log_entry.md))</code> static {#method-time data-toc-label='time'}
+***

--- a/docs/api/mod_loader_log_entry.md
+++ b/docs/api/mod_loader_log_entry.md
@@ -1,3 +1,7 @@
+---
+description: This Sub-Class represents a log entry in ModLoader.
+---
+
 # ModLoaderLog.ModLoaderLogEntry
 **Inherits**: Resource
 

--- a/docs/api/mod_loader_mod.md
+++ b/docs/api/mod_loader_mod.md
@@ -1,5 +1,6 @@
 ---
 status: new
+description: This Class provides helper functions to build mods.
 ---
 
 # ModLoaderMod
@@ -269,11 +270,7 @@ Returns true if the mod with the given `#!gd mod_id` was successfully loaded.
 ***
 ### • [`#!gd bool`](https://docs.godotengine.org/en/stable/classes/class_bool.html) <code class="highlight">is_mod_active(mod_id: [String](https://docs.godotengine.org/en/stable/classes/class_string.html))</code> static {#method-is_mod_active data-toc-label='is_mod_active'}
 #### Description:
-#### Parameters:
-  
-- `#!gd mod_id` ([`#!gd String`](https://docs.godotengine.org/en/stable/classes/class_string.html)): The ID of the mod.
-
-**Returns:**
-
-- [`#!gd bool`](https://docs.godotengine.org/en/stable/classes/class_bool.html): true if the mod is loaded and active, false otherwise.
+Returns true if the mod with the given mod_id was successfully loaded and is currently active.   
+Parameters: - `#!gd mod_id` ([`#!gd String`](https://docs.godotengine.org/en/stable/classes/class_string.html)): The ID of the mod.   
+Returns: - [`#!gd bool`](https://docs.godotengine.org/en/stable/classes/class_bool.html): true if the mod is loaded and active, false otherwise.
 ***

--- a/docs/api/mod_loader_user_profile.md
+++ b/docs/api/mod_loader_user_profile.md
@@ -1,3 +1,7 @@
+---
+description: This Class provides methods for working with user profiles.
+---
+
 # ModLoaderUserProfile
 **Inherits**: Object
 

--- a/xml_to_md.py
+++ b/xml_to_md.py
@@ -114,14 +114,22 @@ def xml_to_markdown(xml_string):
 	inherits = root.get('inherits')
 
 	md = ""
-	if class_name == "ModLoaderMod":  # make it stand out a bit more in the list
-		md += "---\nstatus: new\n---\n\n"
+
+		# Process brief description for meta data
+	brief_desc = root.find('brief_description')
+	if brief_desc is not None and brief_desc.text.strip() != "":
+		
+		brief_desc_text = brief_desc.text.split("[br]")[0]
+
+		if class_name == "ModLoaderMod":  # make it stand out a bit more in the list
+			md += f"---\nstatus: new\ndescription: {bbcode_to_markdown(brief_desc_text)}\n---\n\n"
+		else:
+			md += f"---\ndescription: {bbcode_to_markdown(brief_desc_text)}\n---\n\n"
 
 	md += f"# {class_name}\n"
 	md += f"**Inherits**: {inherits}\n\n"
 
 	# Process brief description
-	brief_desc = root.find('brief_description')
 	if brief_desc is not None:
 		md += f"\n{bbcode_to_markdown(brief_desc.text)}\n"
 


### PR DESCRIPTION
The `brief_description` is now used to fill in the `description` tag in the frontmatter of 4.x API pages.