### PR TITLE
fix: :bug: add the search back

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ theme:
 
 plugins:
   - social
+  - search
 
 extra:
   social:


### PR DESCRIPTION
![The built-in search plugin integrates seamlessly with Material for MkDocs, adding multilingual client-side search with [lunr](https://lunrjs.com/) and [lunr-languages](https://github.com/MihaiValentin/lunr-languages). It's enabled by default, but must be re-added to mkdocs.yml when other plugins are used:](https://github.com/user-attachments/assets/165d32d7-40b6-4c45-89f3-5514f1100000)
https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/?h=searc#built-in-search-plugin